### PR TITLE
Add FileShare.ReadWrite for prevents IOException

### DIFF
--- a/Source/ControlLog.xaml.cs
+++ b/Source/ControlLog.xaml.cs
@@ -89,7 +89,7 @@ namespace LogViewer2
                 {
                     byte[] tempBuffer = new byte[1024 * 1024];
 
-                    this.fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+                    this.fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     FileInfo fileInfo = new FileInfo(filePath);
 
                     // Calcs and finally point the position to the end of the line

--- a/Source/LogFile.cs
+++ b/Source/LogFile.cs
@@ -78,7 +78,7 @@ namespace LogViewer2
                 {                    
                     byte[] tempBuffer = new byte[1024 * 1024];
 
-                    this.fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+                    this.fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     FileInfo fileInfo = new FileInfo(filePath);
 
                     // Calcs and finally point the position to the end of the line


### PR DESCRIPTION
Without FileShare .ReadWrite opened and used log files throws IOException: The process cannot access the file because it is being used by another process.